### PR TITLE
Add CI, dependabot, stale-bot, and maintenance guide

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # JavaScript dependencies (yarn.lock, classic Yarn v1)
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+name: Close stale issues and PRs
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v11
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had recent activity. It will be closed if no further activity occurs.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has not had recent activity. It will be closed if no further activity
+            occurs.
+          days-before-issue-stale: 60
+          days-before-issue-close: -1
+          days-before-pr-stale: 30
+          days-before-pr-close: -1
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-pr-labels: dependencies

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,0 +1,77 @@
+# Maintaining Awesome Portfolio
+
+This guide covers the day-to-day maintenance of the [awesome-portfolio](https://github.com/piyush97/awesome-portfolio) repository.
+
+## Tooling
+
+| Concern | Tool | Notes |
+|---|---|---|
+| Package manager | **Yarn (classic v1)** | `yarn.lock` is the canonical lockfile. Yarn is pinned to v1 semantics — run `yarn set version classic` if Yarn Berry prompts are seen. |
+| Runtime | **Node.js 20 LTS** | CI pins `actions/setup-node@v4` with `node-version: 20` and `cache: yarn`. |
+| Framework | Vite 5 + React 18 + TypeScript 5 | Build is `tsc && vite build`; output goes to `build/`. |
+| Styling | Tailwind CSS v3 + daisyUI v4 | Theme switching in `tailwind.config.js`. |
+
+## CI
+
+`.github/workflows/ci.yml` runs on every push to `main` and on every pull request:
+
+1. `actions/checkout@v4`
+2. `actions/setup-node@v4` (Node 20, yarn cache)
+3. `yarn install --frozen-lockfile`
+4. `yarn build` (`tsc && vite build`)
+
+**Note on `yarn lint`:** `package.json` currently ships a `lint` script (`eslint src --ext ts,tsx --report-unused-disable-directives`) but **eslint is not declared in `devDependencies`** and no ESLint config exists in the repo, so `yarn lint` fails with `eslint: command not found`. CI intentionally runs **build only**. To restore linting, add ESLint as a dev dependency and commit an ESLint config (flat or legacy) — then add a `yarn lint` step to `ci.yml`.
+
+Local CI equivalent:
+
+```bash
+yarn install --frozen-lockfile
+yarn build
+```
+
+## Dependabot
+
+`.github/dependabot.yml` enables two update streams:
+
+| Ecosystem | Schedule | What it manages |
+|---|---|---|
+| `npm` (Yarn v1 lockfile) | Weekly, Monday 06:00 | All `dependencies` / `devDependencies` from `yarn.lock`; `minor` and `patch` updates are grouped into a single "minor-patch" PR |
+| `github-actions` | Weekly | Version bumps for actions used in workflows |
+
+- Up to **5** open dependabot PRs at a time per ecosystem.
+- Every dependabot PR is labeled `dependencies`.
+- **Review and merge**: check the PR's diff against the current `package.json` range, confirm the `build` check is green, then merge. `minor`/`patch` groups are low risk; major bumps deserve a manual look (especially `vite`, `react`, `typescript`, `tailwindcss`).
+
+## Stale issues & PRs
+
+`.github/workflows/stale.yml` (schedule: Mondays 09:00 UTC) marks:
+
+- Issues inactive **60 days** → labeled `stale` (never auto-closed)
+- PRs inactive **30 days** → labeled `stale` (never auto-closed; PRs labeled `dependencies` are exempt)
+
+The workflow **comments and labels only — it never closes anything**. Review `stale`-labeled items and either act or remove the label.
+
+## Release process
+
+There is no formal release cadence — the `main` branch is the release branch and Vercel deploys automatically.
+
+1. Make changes on a feature branch, push, and open a PR against `main`.
+2. Wait for the `build` check to go green.
+3. Merge with squash (`gh pr merge --squash`).
+4. Verify the deploy on [Vercel](https://vercel.com) (preview deploys comment on the PR; production deploys from `main`).
+
+## Verification commands
+
+```bash
+# After a merge or dependency update
+gh pr view <PR> -R piyush97/awesome-portfolio --json state,mergeCommit
+gh api repos/piyush97/awesome-portfolio/commits/main --jq .sha          # == merge commit SHA
+gh run list -R piyush97/awesome-portfolio --branch main --limit 3      # CI conclusion == success
+
+# Local sanity check
+yarn install --frozen-lockfile && yarn build
+```
+
+## Contact
+
+Open an issue for anything this guide doesn't cover.


### PR DESCRIPTION
## Summary

Adds automated upkeep for this repository:

- **`.github/workflows/ci.yml`** — new CI on push to `main` and pull requests: checkout, setup-node 20 (yarn cache), `yarn install --frozen-lockfile`, `yarn build`. (The `lint` script is currently broken — `eslint` is not declared in `devDependencies` and has no config — so CI is build-only; see MAINTAINING.md.)
- **`.github/dependabot.yml`** — weekly dependency updates for `npm` (yarn.lock, Monday 06:00, minor+patch grouped, up to 5 PRs, `dependencies` label) and `github-actions`.
- **`.github/workflows/stale.yml`** — `actions/stale@v11`: issues stale after 60 days, PRs after 30 days; labels only, **never auto-closes**; PRs labeled `dependencies` exempt.
- **`MAINTAINING.md`** — maintenance runbook: CI, dependabot policy, stale policy, release, verification commands.

## Validation

- All three YAML files parse (`YAML.load_file`).
- Local CI-equivalent gate passes from clean state: `yarn install --frozen-lockfile && yarn build` ✅ (Node 24 locally; CI pins Node 20 LTS).

No tests exist in this repo; CI is build-only health gate.